### PR TITLE
Data type fix for DML queries

### DIFF
--- a/src/NewRelic.Microsoft.SqlServer.Plugin/Queries/SqlDMLActivity.SqlServerAndAzureSQL.sql
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/Queries/SqlDMLActivity.SqlServerAndAzureSQL.sql
@@ -18,10 +18,10 @@ declare @SqlText as table(
 	plan_handle varbinary(64),
 	SqlStatement nvarchar(max),
 	creation_time DATETIME,
-	execution_count INT,
-	total_logical_writes INT,
-	total_logical_reads INT,
-	total_physical_reads INT	
+	execution_count BIGINT,
+	total_logical_writes BIGINT,
+	total_logical_reads BIGINT,
+	total_physical_reads BIGINT	
 )
 
 

--- a/src/NewRelic.Microsoft.SqlServer.Plugin/QueryTypes/SqlDmlActivity.cs
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/QueryTypes/SqlDmlActivity.cs
@@ -12,7 +12,7 @@ namespace NewRelic.Microsoft.SqlServer.Plugin.QueryTypes
 		public Byte[] PlanHandle { get; set; }
 
 		[Metric(Ignore = true)]
-		public int ExecutionCount { get; set; }
+		public long ExecutionCount { get; set; }
 
 		[Metric(Ignore = true)]
 		public string QueryType { get; set; }
@@ -23,9 +23,9 @@ namespace NewRelic.Microsoft.SqlServer.Plugin.QueryTypes
 		[Metric(Ignore = true)]
 		public DateTime CreationTime { get; set; }
 
-		public int Writes { get; set; }
+		public long Writes { get; set; }
 
-		public int Reads { get; set; }
+		public long Reads { get; set; }
 
 		public override string ToString()
 		{

--- a/src/NewRelic.Microsoft.SqlServer.Plugin/SqlEndpoint.cs
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/SqlEndpoint.cs
@@ -190,8 +190,8 @@ namespace NewRelic.Microsoft.SqlServer.Plugin
 
 			var currentValues = sqlDmlActivities.ToDictionary(a => string.Format("{0}:{1}:{2}", BitConverter.ToString(a.PlanHandle), a.SQlStatement, a.CreationTime));
 
-			var reads = 0;
-			var writes = 0;
+			long reads = 0;
+			long writes = 0;
 
 			// If this is the first time through, reads and writes are definitely 0
 			if (SqlDmlActivityHistory.Count > 0)
@@ -199,7 +199,7 @@ namespace NewRelic.Microsoft.SqlServer.Plugin
 				currentValues
 					.ForEach(a =>
 					         {
-						         int increase;
+						         long increase;
 
 						         // Find a matching previous value for a delta
 						         SqlDmlActivity previous;


### PR DESCRIPTION
The data type of some of the columns specified in the SqlText table in the DML query were incorrect, they were specified as INT instead of BIGINT. When attempting to aggregate data larger than an INT the query throws:

Arithmetic overflow error converting expression to data type int.
The statement has been terminated.

The columns in question are:

execution_count
total_logical_writes
total_logical_reads
total_physical_reads

Further info on the data types for these columns can be found at:
http://msdn.microsoft.com/en-us/library/ms189741.aspx 
