### PR TITLE
Implemented collection of resource stats for Windows Azure SQL Database.

### DIFF
--- a/src/NewRelic.Microsoft.SqlServer.Plugin/AzureSqlEndpoint.cs
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/AzureSqlEndpoint.cs
@@ -42,7 +42,7 @@ namespace NewRelic.Microsoft.SqlServer.Plugin
 
 		public override IEnumerable<IQueryContext> ExecuteQueries(ILog log)
 		{
-			return base.ExecuteQueries(log).Concat(PerformThrottlingQuery(log));
+			return base.ExecuteQueries(log).Concat(PerformMasterDatabaseQueries(log));
 		}
 
 		/// <summary>
@@ -50,9 +50,14 @@ namespace NewRelic.Microsoft.SqlServer.Plugin
 		/// </summary>
 		/// <param name="log"></param>
 		/// <returns></returns>
-		internal IEnumerable<IQueryContext> PerformThrottlingQuery(ILog log)
+		internal IEnumerable<IQueryContext> PerformMasterDatabaseQueries(ILog log)
 		{
-			var queries = new QueryLocator(new DapperWrapper()).PrepareQueries(new[] {typeof (AzureServiceInterruptionEvents)}, false).ToArray();
+			var queries = new QueryLocator(new DapperWrapper())
+               .PrepareQueries(new[]
+                               {
+                                    typeof (AzureServiceInterruptionEvents),
+                                    typeof (AzureSqlResourceStats)
+                               }, false).ToArray();
 			return ExecuteQueries(queries, _masterConnectionString, log);
 		}
 	}

--- a/src/NewRelic.Microsoft.SqlServer.Plugin/NewRelic.Microsoft.SqlServer.Plugin.csproj
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/NewRelic.Microsoft.SqlServer.Plugin.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ISqlQuery.cs" />
     <Compile Include="MetricQuery.cs" />
     <Compile Include="QueryTypes\AzureServiceInterruptionEvents.cs" />
+    <Compile Include="QueryTypes\AzureSqlResourceStats.cs" />
     <Compile Include="QueryTypes\AzureSqlDatabaseSummary.cs" />
     <Compile Include="QueryTypes\SqlServerDetails.cs" />
     <Compile Include="QueryTypes\DatabaseDetails.cs" />
@@ -189,6 +190,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Queries\DatabaseDetails.SqlServer.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Queries\ResourceStats.AzureSQL.sql" />
   </ItemGroup>
   <Import Project="..\Common\NewRelic.Microsoft.SqlServer.Plugin.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NewRelic.Microsoft.SqlServer.Plugin/Queries/ResourceStats.AzureSQL.sql
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/Queries/ResourceStats.AzureSQL.sql
@@ -1,0 +1,18 @@
+-- Resource statistics
+-- Master DB Azure
+-- SQL Azure Only
+-- Microsoft introduced Windows Azure SQL Database Premium end of 2013. The Premium database
+-- comes with reserved resources for CPU, Memory and IO. Use the new resource_stats view
+-- to determine how much of your quota you are using.
+-- http://msdn.microsoft.com/en-us/library/windowsazure/dn369873.aspx
+
+SELECT TOP(1)
+	avg_cpu_cores_used AS AvgCpuCoresUsed,
+	avg_physical_read_iops AS AvgPhysicalReadIops,
+	avg_physical_write_iops AS AvgPhysicalWriteIops,
+	active_memory_used_kb AS ActiveMemoryUsed,
+	active_session_count AS ActiveSessionCount,
+	active_worker_count AS ActiveWorkerCount
+FROM sys.resource_stats
+/*{WHERE}*/
+ORDER BY end_time desc

--- a/src/NewRelic.Microsoft.SqlServer.Plugin/QueryTypes/AzureSqlResourceStats.cs
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/QueryTypes/AzureSqlResourceStats.cs
@@ -38,9 +38,10 @@ namespace NewRelic.Microsoft.SqlServer.Plugin.QueryTypes
          return string.Format("AvgCpuCoresUsed: {0},\t" +
                               "AvgPhysicalReadIops: {1},\t" +
                               "AvgPhysicalWriteIops: {2},\t" +
-                              "ActiveSessionCount: {3},\t" +
-                              "ActiveWorkerCount: {4}",
-                              AvgCpuCoresUsed, AvgPhysicalReadIops, AvgPhysicalWriteIops, ActiveSessionCount, ActiveWorkerCount);
+                              "ActiveMemoryUsed: {3},\t" +
+                              "ActiveSessionCount: {4},\t" +
+                              "ActiveWorkerCount: {5}",
+                              AvgCpuCoresUsed, AvgPhysicalReadIops, AvgPhysicalWriteIops, ActiveMemoryUsed, ActiveSessionCount, ActiveWorkerCount);
       }
    }
 

--- a/src/NewRelic.Microsoft.SqlServer.Plugin/QueryTypes/AzureSqlResourceStats.cs
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/QueryTypes/AzureSqlResourceStats.cs
@@ -1,0 +1,48 @@
+using NewRelic.Microsoft.SqlServer.Plugin.Core;
+
+namespace NewRelic.Microsoft.SqlServer.Plugin.QueryTypes
+{
+   [AzureSqlQuery("ResourceStats.AzureSQL.sql", "Component/ResourceStats/{MetricName}", QueryName = "Azure SQL Resource Statistics", Enabled = false)]
+   public class AzureSqlResourceStats : DatabaseMetricBase
+   {
+      [Metric(MetricValueType = MetricValueType.Value, Units = "[cores]")]
+      public decimal AvgCpuCoresUsed { get; set; }
+
+      [Metric(MetricValueType = MetricValueType.Value, Units = "[iops]")]
+      public decimal AvgPhysicalReadIops { get; set; }
+
+      [Metric(MetricValueType = MetricValueType.Value, Units = "[iops]")]
+      public decimal AvgPhysicalWriteIops { get; set; }
+
+      [Metric(MetricValueType = MetricValueType.Value, Units = "[KB]")]
+      public int ActiveMemoryUsed { get; set; }
+
+      [Metric(MetricValueType = MetricValueType.Value, Units = "[sessions]")]
+      public int ActiveSessionCount { get; set; }
+
+      [Metric(MetricValueType = MetricValueType.Value, Units = "[workers]")]
+      public int ActiveWorkerCount { get; set; }
+
+      protected override WhereClauseTokenEnum WhereClauseToken
+      {
+         get { return WhereClauseTokenEnum.Where; }
+      }
+
+      protected override string DbNameForWhereClause
+      {
+         get { return "database_name"; }
+      }
+
+      public override string ToString()
+      {
+         return string.Format("AvgCpuCoresUsed: {0},\t" +
+                              "AvgPhysicalReadIops: {1},\t" +
+                              "AvgPhysicalWriteIops: {2},\t" +
+                              "ActiveSessionCount: {3},\t" +
+                              "ActiveWorkerCount: {4}",
+                              AvgCpuCoresUsed, AvgPhysicalReadIops, AvgPhysicalWriteIops, ActiveSessionCount, ActiveWorkerCount);
+      }
+   }
+
+}
+


### PR DESCRIPTION
A couple of months ago a new dynamic management view was added to Windows Azure SQL Database. This view (resource_stats) contains some central performance metrics for the databases. For example, it allows you to see how many CPU cores you currently use. 

If you purchase Windows Azure SQL Database Premium Edition, you get reserved resource (for example 1 CPU core) and this commit allows you to see how much of these resources you actually used. We've been recommended by Microsoft to continously monitor the resource_stats, so I thought that adding it to the New Relic plug-in would be a good idea. We are currently running these changes in preview in our own production.
