### PR TITLE
Add connection examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,25 @@ Server=remote-server;Database=master;Trusted_Connection=True;
 
 ##### Azure SQL
 
+The connection string for an Azure SQL database is slightly different.  The example from the plugin.json is below:
+
+```
+Server=tcp:{Azure SQL Server Name}.database.windows.net,1433;Database={Azure SQL Database Name};User ID={Azure SQL User Name}@{Azure SQL Server Name};Password={Password for User Name};Trusted_Connection=False;Encrypt=True;Connection Timeout=30;
+```
+
+It recommend to simply insert the requested details and not alter this connection string to much since it is specifically designed to work with Azure.  You will only need to fill in the following details:
+
+Azure SQL Server Name (in two places)
+Azure SQL Database Name
+Azure SQL User Name
+Password for User Name
+
+Below is a string that has been filled out with some test data:
+
+```
+Server=tcp:azure-sql-svr.database.windows.net,1433;Database=my-database;User ID=myUser@azure-sql-svr;Password=password;Trusted_Connection=False;Encrypt=True;Connection Timeout=30;
+```
+
 TODO
 
 ### Additional Configuration

--- a/README.md
+++ b/README.md
@@ -170,6 +170,51 @@ Example:
 }
 ```
 
+#### Configure connectionString
+
+You will need to modify the example connection string found in the plugin.json file in order for the plugin to find and connect to your SQL server.  The connectionString is standard Microsoft SQL connection string.  You can find more details about connection strings [here](https://www.connectionstrings.com/sql-server/).
+
+**note** - Please make sure to escape the backslashes, "\", in your connection string by using two backslashes, "\\".
+
+##### SQL Server
+
+Below is the example connection string included in the plugin.json: (without quotes)
+
+```
+Server=.\\SQLExpress;Database=master;Trusted_Connection=True;
+```
+
+Below is the break down of what each value represents:
+
+Server Name: .  (shorthand for local server)
+SQL Instance: SQLExpress
+Database to connect to: Database=master
+Connection type: Trusted_Connection=True
+
+This tells the plugin: "As the current user of the process, connect to the local server and then attach to the SQLExpress instance and open the database named master".  
+
+Connecting to another server would require the server name to be used in place of ".". For example:
+
+```
+Server=remote-server\\SQLExpress;Database=master;Trusted_Connection=True;
+```
+
+If you are not attempting to connect to the default SQL instance the SQL instance name must be provided like in the example below:
+
+```
+Server=.\\MyCustomInstance;Database=master;Trusted_Connection=True;
+```
+
+If using the default the connection string can be simplified like the following:
+
+```
+Server=remote-server;Database=master;Trusted_Connection=True;
+```
+
+##### Azure SQL
+
+TODO
+
 ### Additional Configuration
  
 #### Configure permissions

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You will need to modify the example connection string found in the plugin.json f
 
 **note** - Please make sure to escape the backslashes, "\", in your connection string by using two backslashes, "\\".
 
-##### SQL Server
+##### SQL Server Databases (not hosted in Azure)
 
 Below is the example connection string included in the plugin.json: (without quotes)
 
@@ -211,7 +211,7 @@ If using the default the connection string can be simplified like the following:
 Server=remote-server;Database=master;Trusted_Connection=True;
 ```
 
-##### Azure SQL
+##### Azure-hosted SQL Databases
 
 The connection string for an Azure SQL database is slightly different.  The example from the plugin.json is below:
 

--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ Server=.\\SQLExpress;Database=master;Trusted_Connection=True;
 
 Below is the break down of what each value represents:
 
-Server Name: .  (shorthand for local server)
-SQL Instance: SQLExpress
-Database to connect to: Database=master
-Connection type: Trusted_Connection=True
+* Server Name: .  (shorthand for local server)
+* SQL Instance: SQLExpress
+* Database to connect to: Database=master
+* Connection type: Trusted_Connection=True
 
 This tells the plugin: "As the current user of the process, connect to the local server and then attach to the SQLExpress instance and open the database named master".  
 
@@ -221,18 +221,16 @@ Server=tcp:{Azure SQL Server Name}.database.windows.net,1433;Database={Azure SQL
 
 It recommend to simply insert the requested details and not alter this connection string to much since it is specifically designed to work with Azure.  You will only need to fill in the following details:
 
-Azure SQL Server Name (in two places)
-Azure SQL Database Name
-Azure SQL User Name
-Password for User Name
+* Azure SQL Server Name (in two places)
+* Azure SQL Database Name
+* Azure SQL User Name
+* Password for User Name
 
 Below is a string that has been filled out with some test data:
 
 ```
 Server=tcp:azure-sql-svr.database.windows.net,1433;Database=my-database;User ID=myUser@azure-sql-svr;Password=password;Trusted_Connection=False;Encrypt=True;Connection Timeout=30;
 ```
-
-TODO
 
 ### Additional Configuration
  

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Example:
 }
 ```
 
-#### Configure connectionString
+#### Configuring the connectionString
 
 You will need to modify the example connection string found in the plugin.json file in order for the plugin to find and connect to your SQL server.  The connectionString is standard Microsoft SQL connection string.  You can find more details about connection strings [here](https://www.connectionstrings.com/sql-server/).
 


### PR DESCRIPTION
Added a new section to the configuration detailing the connection string for on-prem and Azure SQL databases along with some examples.  Also includes a link to connectionstrings.com.
