### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ Example:
 {
   "license_key": "YOUR_LICENSE_KEY_HERE"
   "log_level": "debug",
-  "log_file_path": "C:\\Logs"
+  "log_file_path": "C:\\Logs",
+  "log_limit_in_kbytes": 25600
 }
 ```
 


### PR DESCRIPTION
Include log_limit_in_kbytes in example.

I found that the default log size isn't actually set to 25600 as the README says. I skipped over `log_limit_in_kbytes` because it wasn't included in the example.  I don't see where to submit a pull request for the SDK, I can dig into it a little bit later.
