### PR TITLE
Add CPU, I/O and memory consumption for an Azure SQL DB

### DIFF
--- a/src/NewRelic.Microsoft.SqlServer.Plugin/NewRelic.Microsoft.SqlServer.Plugin.csproj
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/NewRelic.Microsoft.SqlServer.Plugin.csproj
@@ -83,6 +83,7 @@
     <Compile Include="MetricQuery.cs" />
     <Compile Include="QueryTypes\AzureServiceInterruptionEvents.cs" />
     <Compile Include="QueryTypes\AzureSqlDatabaseSummary.cs" />
+    <Compile Include="QueryTypes\ResourceStats.cs" />
     <Compile Include="QueryTypes\SqlServerDetails.cs" />
     <Compile Include="QueryTypes\DatabaseDetails.cs" />
     <Compile Include="QueryTypes\RecompileMaximums.cs" />
@@ -172,7 +173,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Queries\DatabaseDetails.SqlServer.sql" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <EmbeddedResource Include="Queries\ResourceStats.AzureSql.sql" />
+  </ItemGroup>
   <Import Project="..\Common\NewRelic.Microsoft.SqlServer.Plugin.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/src/NewRelic.Microsoft.SqlServer.Plugin/Queries/ResourceStats.AzureSql.sql
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/Queries/ResourceStats.AzureSql.sql
@@ -1,0 +1,15 @@
+﻿-- sys.dm_db_resource_stats exposes 'fine-grained', near real-time resource consumption data,
+-- expressed as a percentage of the maximum allowed DTU limits for the service tier/performance
+-- level that the db is running (https://msdn.microsoft.com/en-us/library/dn800981.aspx)
+
+SELECT
+	AVG(avg_cpu_percent) AS [AvgCpuPercent], 
+	MAX(avg_cpu_percent) AS [MaxCpuPercent],
+	AVG(avg_data_io_percent) AS [AvgDataIoPercent], 
+	MAX(avg_data_io_percent) AS [MaxDataIoPercent],
+	AVG(avg_log_write_percent) AS [AvgLogWritePercent], 
+	MAX(avg_log_write_percent) AS [MaxLogWritePercent],
+	AVG(avg_memory_usage_percent) AS [AvgMemoryUsagePercent], 
+	MAX(avg_memory_usage_percent) AS [MaxMemoryUsagePercent]
+FROM (SELECT TOP 4 * FROM sys.dm_db_resource_stats) t
+-- TOP 4 since plugin works in 1min interval, table is filled in 15sec interval

--- a/src/NewRelic.Microsoft.SqlServer.Plugin/QueryTypes/ResourceStats.cs
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/QueryTypes/ResourceStats.cs
@@ -1,0 +1,52 @@
+﻿using NewRelic.Microsoft.SqlServer.Plugin.Core;
+
+using System;
+
+namespace NewRelic.Microsoft.SqlServer.Plugin.QueryTypes
+{
+    [AzureSqlQuery("ResourceStats.AzureSql.sql", "ResourceStats/{MetricName}", QueryName = "Resource Stats", Enabled = true)]
+    public class ResourceStats
+    {
+
+        [Metric(MetricValueType = MetricValueType.Value, Units = "%_Avg_Cpu")]
+        public decimal AvgCpuPercent { get; set; }
+
+        [Metric(MetricValueType = MetricValueType.Value, Units = "%_Max_Cpu")]
+        public decimal MaxCpuPercent { get; set; }
+
+        [Metric(MetricValueType = MetricValueType.Value, Units = "%_Avg_Data_Io")]
+        public decimal AvgDataIoPercent { get; set; }
+
+        [Metric(MetricValueType = MetricValueType.Value, Units = "%_Max_Data_Io")]
+        public decimal MaxDataIoPercent { get; set; }
+
+        [Metric(MetricValueType = MetricValueType.Value, Units = "%_Avg_Log_Write")]
+        public decimal AvgLogWritePercent { get; set; }
+
+        [Metric(MetricValueType = MetricValueType.Value, Units = "%_Max_Log_Write")]
+        public decimal MaxLogWritePercent { get; set; }
+
+        [Metric(MetricValueType = MetricValueType.Value, Units = "%_Avg_Memory_Usage")]
+        public decimal AvgMemoryUsagePercent { get; set; }
+
+        [Metric(MetricValueType = MetricValueType.Value, Units = "%_Max_Memory_Usage")]
+        public decimal MaxMemoryUsagePercent { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format(   "AvgCpuPercent: {0},\t" +
+                                    "MaxCpuPercent: {1},\t" +
+                                    "AvgDataIoPercent: {2},\t" +
+                                    "MaxDataIoPercent: {3},\t" +
+                                    "AvgLogWritePercent: {4},\t" +
+                                    "MaxLogWritePercent: {5},\t" +
+                                    "AvgMemoryUsagePercent: {6},\t" +
+                                    "MaxMemoryUsagePercent: {7},\t",
+                                    AvgCpuPercent, MaxCpuPercent,
+                                    AvgDataIoPercent, MaxDataIoPercent,
+                                    AvgLogWritePercent, MaxLogWritePercent,
+                                    AvgMemoryUsagePercent, MaxMemoryUsagePercent);
+        }
+
+    }
+}


### PR DESCRIPTION
I noticed that my PR is actually very similar to the one of @martinknafve. (Sorry I didn't look at the other PRs before adding this change) But still, this one uses sys.dm_db_resource_stats which is more granular (15sec updates) instead of the sys.resource_stats (300sec updates). Furthermore as you've already seen the other PR is not V12 compatible, since Microsoft changed the DMV, this one is for V12, I thought maybe it is useful for others too and therefore the PR. :-)
