### PR TITLE
Updated config file location handling to be os agnostic

### DIFF
--- a/src/NewRelic.Microsoft.SqlServer.Plugin/Configuration/ConfigurationParser.cs
+++ b/src/NewRelic.Microsoft.SqlServer.Plugin/Configuration/ConfigurationParser.cs
@@ -22,7 +22,7 @@ namespace NewRelic.Microsoft.SqlServer.Plugin.Configuration
         /// </exception>
         public static Settings ParseSettings()
         {
-            const string defaultConfigPath = @".\config\plugin.json";
+            string defaultConfigPath = Path.Combine("config", "plugin.json");
 
             INewRelicConfig newrelicConfig = NewRelicConfig.Instance;
             string pluginConfigPath = Path.Combine(Assembly.GetExecutingAssembly().GetLocalPath(), defaultConfigPath);


### PR DESCRIPTION
If this plugin is run on Linux (mono), it breaks because of two reasons:
1. NewRelic.Platform.Sdk `newrelic.json` file path handling
(https://github.com/newrelic-platform/newrelic_dotnet_sdk/pull/42)
2. Updated file handling `plugin.json` inside this code change

QUESTION: To wait for a release of SDK or to go forward with this one and to create another pull request when SDK change passes?